### PR TITLE
fix: resolve blank white page on root URL for authenticated users

### DIFF
--- a/src/app/(auth)/layout.tsx
+++ b/src/app/(auth)/layout.tsx
@@ -3,6 +3,7 @@
 import { useEffect } from "react";
 import { useRouter } from "next/navigation";
 import { useAuth } from "@/features/auth";
+import { getRoleHome } from "@/lib/routes";
 
 /**
  * Auth Route Layout
@@ -21,17 +22,8 @@ export default function AuthRouteLayout({
     if (isLoading) return; // wait for hydration
     if (!isAuthed || !user) return;
 
-    // Redirect based on role
-    switch (user.role) {
-      case "PHARMACY":
-        router.replace("/pharmacy/home");
-        break;
-      case "ADMIN":
-        router.replace("/admin/dashboard");
-        break;
-      default:
-        router.replace("/");
-    }
+    // Send the authenticated user to their role's correct destination.
+    router.replace(getRoleHome(user.role));
   }, [isAuthed, isLoading, user, router]);
 
   // While loading or if authenticated (redirect in progress), show spinner

--- a/src/features/auth/AuthGuard.tsx
+++ b/src/features/auth/AuthGuard.tsx
@@ -4,48 +4,91 @@ import { useEffect } from "react";
 import { useRouter, usePathname } from "next/navigation";
 import { useAuth } from "./useAuth";
 import AccountUnderReview from "@/components/pharmacy/shared/AccountUnderReview";
+import { getRoleHome, isAppRole, ROUTES } from "@/lib/routes";
 
 type Props = {
   children: React.ReactNode;
   allowedRoles?: string[];
 };
 
+/**
+ * Full-screen loader shown while the session is being resolved or while a
+ * role-based redirect is in flight. Guarantees the guard never renders a blank
+ * white page (the previous implementation returned `null`).
+ */
+function AuthLoadingScreen() {
+  return (
+    <div
+      className="min-h-screen flex items-center justify-center bg-gray-50"
+      role="status"
+      aria-live="polite"
+      aria-busy="true"
+    >
+      <div className="w-8 h-8 border-4 border-primary border-t-transparent rounded-full animate-spin" />
+      <span className="sr-only">Loading…</span>
+    </div>
+  );
+}
+
 export function AuthGuard({ children, allowedRoles }: Props) {
   const { isAuthed, isLoading, user, profile } = useAuth();
   const router = useRouter();
   const pathname = usePathname();
 
-  const isPharmacy = user?.role === "PHARMACY";
+  const role = user?.role ?? null;
+  const isPharmacy = role === "PHARMACY";
   const isUnderReview =
     isPharmacy && profile?.verificationStatus === "UNDER_REVIEW";
+
+  // A user passes the role check when no roles are required, or when their
+  // (known) role is explicitly allowed for this section.
+  const isRoleAllowed =
+    !allowedRoles || (isAppRole(role) && allowedRoles.includes(role));
 
   useEffect(() => {
     if (isLoading) return;
 
-    if (!isAuthed) {
-      router.replace("/auth/sign-in");
+    // 1. Unauthenticated → sign-in.
+    if (!isAuthed || !user) {
+      router.replace(ROUTES.AUTH.SIGN_IN);
       return;
     }
 
-    if (allowedRoles && !allowedRoles.includes(user?.role ?? "")) {
-      router.replace("/");
+    // 2. Corrupt session (missing / unexpected role) → force re-auth instead of
+    //    looping forever on a page the role can't render.
+    if (!isAppRole(role)) {
+      router.replace(ROUTES.AUTH.SIGN_IN);
       return;
     }
 
+    // 3. Authenticated but not allowed in this section → send the user to THEIR
+    //    own home, not back to the current page (which caused the blank-page
+    //    self-redirect loop). Guard against redirecting to the current path.
+    if (!isRoleAllowed) {
+      const dest = getRoleHome(role);
+      if (dest !== pathname) {
+        router.replace(dest);
+      }
+      return;
+    }
+
+    // 4. Pharmacy under review stays on the review screen.
     if (isUnderReview) return;
 
+    // 5. Verified pharmacy that somehow landed outside its portal → home.
     if (
       isPharmacy &&
       profile?.verificationStatus === "VERIFIED" &&
       !pathname.startsWith("/pharmacy")
     ) {
-      router.replace("/pharmacy/home");
+      router.replace(ROUTES.PHARMACY.HOME);
     }
   }, [
     isAuthed,
     isLoading,
     user,
-    allowedRoles,
+    role,
+    isRoleAllowed,
     router,
     profile,
     pathname,
@@ -53,9 +96,11 @@ export function AuthGuard({ children, allowedRoles }: Props) {
     isUnderReview,
   ]);
 
-  if (isLoading) return null;
-  if (!isAuthed) return null;
-  if (allowedRoles && !allowedRoles.includes(user?.role ?? "")) return null;
+  // Never render a blank page — show a loader while resolving or redirecting.
+  if (isLoading) return <AuthLoadingScreen />;
+  if (!isAuthed || !user) return <AuthLoadingScreen />;
+  if (!isAppRole(role)) return <AuthLoadingScreen />;
+  if (!isRoleAllowed) return <AuthLoadingScreen />;
 
   if (isUnderReview) {
     return <AccountUnderReview />;

--- a/src/lib/routes.ts
+++ b/src/lib/routes.ts
@@ -82,6 +82,46 @@ export function getHomeRoute(role: "patient" | "pharmacy" | "admin"): string {
 }
 
 /**
+ * Roles that have a dedicated portal/landing destination in this app.
+ */
+export const APP_ROLES = ["PATIENT", "PHARMACY", "ADMIN"] as const;
+export type AppRole = (typeof APP_ROLES)[number];
+
+/**
+ * Returns true when the given value is a known application role.
+ * Used to defensively reject null / undefined / unexpected roles.
+ */
+export function isAppRole(role: unknown): role is AppRole {
+  return typeof role === "string" && (APP_ROLES as readonly string[]).includes(role);
+}
+
+/**
+ * Resolve the correct landing destination for an authenticated user based on
+ * their (uppercase) auth role. This is the single source of truth used by the
+ * route guards so role-based redirects never point a user at a page their
+ * role is not allowed to render.
+ *
+ *   PATIENT  → "/"               (patient portal lives at the root)
+ *   PHARMACY → "/pharmacy/home"
+ *   ADMIN    → "/admin/dashboard"
+ *
+ * Unknown / null / undefined roles fall back to the sign-in page so a corrupt
+ * session can never get stuck rendering a blank screen.
+ */
+export function getRoleHome(role: string | null | undefined): string {
+  switch (role) {
+    case "PATIENT":
+      return ROUTES.PUBLIC.LANDING; // "/"
+    case "PHARMACY":
+      return ROUTES.PHARMACY.HOME; // "/pharmacy/home"
+    case "ADMIN":
+      return ROUTES.ADMIN.DASHBOARD; // "/admin/dashboard"
+    default:
+      return ROUTES.AUTH.SIGN_IN;
+  }
+}
+
+/**
  * Check if a path belongs to a specific portal
  */
 export function isPortalPath(


### PR DESCRIPTION
- Add getRoleHomePath() helper in lib/routes.ts for centralized role-based routing
- Fix AuthGuard redirect loop: wrong-role users now redirect to their correct home instead of '/'
- Replace null render during loading with a full-screen spinner to prevent blank flash
- Add defensive handling for missing session, undefined roles, and unexpected role values
- Auth layout uses getRoleHomePath() consistently for post-login redirects